### PR TITLE
Linking to a commit in the `lug-template` repo instead of its latest ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Slides from LUG's Fall 2025 General Body Meeting.
 - `pdflatex` : LaTeX compilation
 - `rsvg-convert` : Converting svgs
 
-On Debian 13, `apt install make pandoc texlive texlive-fonts-extra librsvg2-bin` should be enough to install all necessary dependencies (it was as of this commit). See https://github.com/lugatuic/lug-template/blob/master/README.md for some more information on all the dependencies except `rsvg-convert`.
+On Debian 13, `apt install make pandoc texlive texlive-fonts-extra librsvg2-bin` should be enough to install all necessary dependencies (it was as of this commit). See https://github.com/lugatuic/lug-template/blob/3126de55b5fce10309096f1f3cc276209a6f422c/README.md for some more information on all the dependencies except `rsvg-convert`.
 
 # Notes
 Running `make` will attempt to convert any markdown files in `src/` to slides PDFs in `out/`.


### PR DESCRIPTION
…state.

When I added more detail to this repository's repository, I added a link to the `lug-template` repo's latest README. With that, if the `lug-template`'s README got updated, this link would automatically point to the updated version. That seemed desirable for some reason, probably because sometimes the README gets fixed simply to better reflect the current state of that template, and the template *seems* like it's in a good state. But I now think that *today's* `lug-template` README is probably the one that will best describe these slides in perpetuity. After all, these slides in this repo are very unlikely to change. So now I'm linking permanently to the current state of the README as of today.